### PR TITLE
Don't explicitly link GTK.

### DIFF
--- a/iup-sys/build.rs
+++ b/iup-sys/build.rs
@@ -1,9 +1,5 @@
 fn main() {
     add_link("iup");
-
-    if cfg!(not(windows)) {
-        add_link("gtk-3"); 
-    }
 }
 
 fn add_link(link: &str) {


### PR DESCRIPTION
Closes #9.