### PR TITLE
Massive refactoring, Widget trait, widgets are `Copy`

### DIFF
--- a/examples/button_test.rs
+++ b/examples/button_test.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate kiss_ui;
 
+use kiss_ui::prelude::*;
+
 use kiss_ui::button::Button;
 use kiss_ui::container::Horizontal;
-use kiss_ui::callback::{OnClick, CallbackStatus};
-use kiss_ui::dialog::{self, AlertPopupBuilder, Dialog};
+use kiss_ui::dialog::{self, AlertPopupBuilder};
 
 fn main() {
     kiss_ui::show_gui(||
@@ -12,20 +13,20 @@ fn main() {
             Horizontal::new(
                 children![               
                     Button::new()
-                        .set_label(Some("Message"))
+                        .set_label("Message")
                         .set_onclick(show_message_dialog),
                     Button::new()
-                        .set_label(Some("Alert"))
+                        .set_label("Alert")
                         .set_onclick(show_alert_dialog),
                     Button::new()
-                        .set_label(Some("Close"))
+                        .set_label("Close")
                         .set_onclick(close_dialog),
                 ]
             )
             .set_elem_spacing_pixels(10)                   
         )
         .set_title("Button test!")
-    );
+    )
 }
 
 fn show_message_dialog(_: Button) {

--- a/examples/progress_test.rs
+++ b/examples/progress_test.rs
@@ -29,9 +29,6 @@ fn main() {
         dialog
             .set_title("Progressbar Test")
             .set_on_show(move |_| {
-                let regular = regular;
-                let dashed = dashed;
-
                 let on_timer_interval = move |timer: Timer|{
                     regular.add_value(0.1);
                     dashed.add_value(0.1);

--- a/examples/progress_test.rs
+++ b/examples/progress_test.rs
@@ -24,27 +24,30 @@ fn main() {
                     ProgressBar::new().set_indefinite(true),
                 ]
             )
-        ).set_title("Progressbar Test");        
+        );        
 
-        dialog.set_on_show(move |_|{
-            // Clone these so they can be moved into the inner closure
-            let mut regular = regular.clone();
-            let mut dashed = dashed.clone();
+        dialog
+            .set_title("Progressbar Test")
+            .set_on_show(move |_| {
+                let regular = regular;
+                let dashed = dashed;
 
-            let on_timer_interval = move |mut timer: Timer|{
-                regular.add_value(0.1);
-                dashed.add_value(0.1);
+                let on_timer_interval = move |timer: Timer|{
+                    regular.add_value(0.1);
+                    dashed.add_value(0.1);
 
-                if regular.get_value() == 1.0 {
-                    timer.stop();
-                }
-            };
+                    if regular.get_value() == 1.0 {
+                        timer.stop();
+                    }
+                };
 
-            Timer::new()
-                .set_interval(1000)
-                .set_on_interval(on_timer_interval)
-                .start()             
-        })
+                Timer::new()
+                    .set_interval(1000)
+                    .set_on_interval(on_timer_interval)
+                    .start();
+            });
+        
+        dialog
     });
 }
 

--- a/examples/textbox_test.rs
+++ b/examples/textbox_test.rs
@@ -1,10 +1,11 @@
 #[macro_use]
 extern crate kiss_ui;
 
+use kiss_ui::prelude::*;
+
 use kiss_ui::button::Button;
-use kiss_ui::callback::OnClick;
 use kiss_ui::container::Vertical;
-use kiss_ui::dialog::{self, Dialog};
+use kiss_ui::dialog;
 use kiss_ui::text::{Label, TextBox};
 
 fn main() {
@@ -13,13 +14,11 @@ fn main() {
             Vertical::new(
                 children![
                     Label::new("Enter a message:"),
-                    {
-                        let mut textbox = TextBox::new().set_visible_columns(20);
-                        textbox.set_name("my_textbox");
-                        textbox
-                    },
+                    TextBox::new()
+                        .set_visible_columns(20)
+                        .set_name("my_textbox"),
                     Button::new()
-                        .set_label(Some("Save"))
+                        .set_label("Save")
                         .set_onclick(show_alert_message),
                 ]
             )

--- a/src/base.rs
+++ b/src/base.rs
@@ -1,134 +1,13 @@
-//! Operations common to all widget types.
+//! A general widget type that can be specialized at runtime.
 
-use utils::cstr::AsCStr;
-
-use dialog::Dialog;
-
-use iup_sys;
+use widget_prelude::*;
 
 use std::borrow::Borrow;
-use std::ffi::{CStr, CString};
-use std::ptr;
 
-/// Defines operations common to all widget types.
-///
-/// Some operations may have no effect for certain widget types.
-///
-/// All widgets must implement `Deref<Target=BaseWidget>` and `DerefMut`.
-pub struct BaseWidget(*mut iup_sys::Ihandle);
+/// A general widget type that can be specialized at runtime via `Downcast`.
+pub struct BaseWidget(IUPPtr);
 
-impl BaseWidget { 
-    /// Show this widget if it was previously hidden.
-    ///
-    /// Does nothing if the widget is already shown, or if the operation does not apply.
-    pub fn show(&mut self) {
-        unsafe { iup_sys::IupShow(self.ptr()); }
-    }
-
-    /// Hide this widget if it was previously visible.
-    ///
-    /// Does nothing if the widget is already hidden, or if the operation does not apply.
-    pub fn hide(&mut self) {
-        unsafe { iup_sys::IupHide(self.ptr()); }
-    }
-
-    /// Set the widget's visibility state.
-    ///
-    /// `.set_visible(true)` is equivalent to calling `.show()`, and `.set_visible(false)`
-    /// is equivalent to calling `.hide()`.
-    ///
-    /// Does nothing if the widget is in the same visibility state as the one being set,
-    /// or if the operation does not apply.
-    pub fn set_visible(&mut self, visible: bool) {
-        self.set_bool_attribute(::attrs::VISIBLE, visible);
-    }
-
-    /// Set the widget's enabled state.
-    ///
-    /// When a widget is disabled, it does not react to user interaction or invoke any callbacks.
-    ///
-    /// Does nothing if the widget does not support being disabled.
-    pub fn set_enabled(&mut self, enabled: bool) {
-        self.set_bool_attribute(::attrs::ACTIVE, enabled);
-    }
-
-    /// Set the position of this widget relative to the top-left corner of its parent.
-    ///
-    /// Does nothing if the widget is not renderable or not attached to a parent.
-    pub fn set_position(&mut self, x: i32, y: i32) {
-        self.set_str_attribute(::attrs::POSITION, format!("{x},{y}", x=x, y=y));
-    }
-
-    /// Get the position of this widget relative to the top-left corner of its parent.
-    ///
-    /// Returns (0, 0) if the widget is not renderable, not attached to a parent, or if that is the
-    /// widget's actual relative position.
-    pub fn get_position(&self) -> (i32, i32) {
-        self.get_int2_attribute(::attrs::POSITION)
-    }
-
-    /// Set the name of the widget so it can be found within its parent.
-    ///
-    /// Does nothing if the widget does not support having a name.
-    pub fn set_name(&mut self, name: &str) {
-        self.set_str_attribute(::attrs::NAME, name);
-    }
-
-    /// Get the name of this widget, if the widget supports having a name and one is set.
-    pub fn get_name(&self) -> Option<&str> {
-        self.get_str_attribute(::attrs::NAME) 
-    }  
-
-    /// Get the next child in the parent after this widget, based on the order in which they were 
-    /// added.
-    ///
-    /// Returns `None` if this widget is an only child or is not attached to a parent.
-    pub fn get_sibling(&self) -> Option<BaseWidget> {
-        unsafe {
-            let ptr = iup_sys::IupGetBrother(self.ptr());
-            Self::from_ptr_opt(ptr)
-        }
-    }
-
-    /// Get the parent of this widget.
-    ///
-    /// Returns `None` if this widget has no parent.
-    pub fn get_parent(&self) -> Option<BaseWidget> {
-        unsafe {
-            let ptr = iup_sys::IupGetParent(self.ptr());
-            Self::from_ptr_opt(ptr)
-        }
-    }
-
-    /// Get the containing dialog of this widget.
-    ///
-    /// Returns `None` if this widget is not attached to a dialog.
-    pub fn get_dialog(&self) -> Option<Dialog> {
-        unsafe {
-            let ptr = iup_sys::IupGetDialog(self.ptr());
-            // Note to self: not using UFCS because `downcast()` is an unsafe function.
-            Self::from_ptr_opt(ptr).map(|base| Dialog::downcast(base))
-        }
-    }
-
-    /// Get the rendered size of this widget, in pixels.
-    ///
-    /// Returns `(0, 0)` if this widget has no rendered size.
-    pub fn get_size_pixels(&self) -> (u32, u32) {
-        let (width, height) = self.get_int2_attribute(::attrs::RASTERSIZE);
-        (width as u32, height as u32)
-    }
-
-    /// Store this widget under `name`, returning the previous widget stored, if any.
-    ///
-    /// It may later be retrieved from any valid KISS-UI context 
-    /// by calling `BaseWidget::load(name)`.
-    pub fn store<N: Into<String>>(&self, name: N) -> Option<BaseWidget> {
-        ::WIDGET_STORE.with(|store| {
-            store.borrow_mut().insert(name.into(), self.clone())
-        })
-    }
-
+impl BaseWidget {
     /// Attempt to load a widget named by `name` from internal storage.
     ///
     /// If successful, the `BaseWidget` can then be downcast to the original widget type.
@@ -154,137 +33,14 @@ impl BaseWidget {
     }
 }
 
-impl Clone for BaseWidget {
-    fn clone(&self) -> Self {
-        BaseWidget(self.0)
-    }
-}
-
-#[doc(hidden)]
-impl ImplDetails for BaseWidget {
-    unsafe fn from_ptr(ptr: *mut iup_sys::Ihandle) -> Self {
-        BaseWidget(ptr)
-    }
-
-    fn ptr(&self) -> *mut iup_sys::Ihandle {
-        self.0
-    }
-}
-
-#[doc(hidden)]
-pub trait ImplDetails: Sized {
-    unsafe fn from_ptr(ptr: *mut iup_sys::Ihandle) -> Self;
-
-    unsafe fn from_ptr_opt(ptr: *mut iup_sys::Ihandle) -> Option<Self> {
-        if !ptr.is_null() {
-            Some(Self::from_ptr(ptr))
-        } else {
-            None
-        }
-    }
-
-    fn ptr(&self) -> *mut iup_sys::Ihandle;    
-
-    fn classname(&self) -> &CStr {
-        unsafe { CStr::from_ptr(iup_sys::IupGetClassName(self.ptr())) } 
-    }
-
-    fn set_str_attribute<V>(&mut self, name: &'static str, val: V) where V: Into<String> {
-        let c_val = CString::new(val.into()).unwrap();
-        unsafe { iup_sys::IupSetStrAttribute(self.ptr(), name.as_cstr(), c_val.as_ptr()); }
-    }
-
-    fn set_opt_str_attribute<V>(&mut self, name: &'static str, val: Option<V>) where V: Into<String> {
-        let c_val = val.map(V::into).map(CString::new).map(Result::unwrap);
-        unsafe { 
-            iup_sys::IupSetStrAttribute(
-                self.ptr(),
-                name.as_cstr(),
-                // This looks backwards, but check the docs. It's right.
-                c_val.as_ref().map_or_else(ptr::null, |c_val| c_val.as_ptr())
-            )
-        }
-    }
-
-    fn set_const_str_attribute(&mut self, name: &'static str, val: &'static str) {
-        unsafe { iup_sys::IupSetAttribute(self.ptr(), name.as_cstr(), val.as_cstr()); }
-    }
-
-    fn get_str_attribute(&self, name: &'static str) -> Option<&str> {
-        let ptr = unsafe { iup_sys::IupGetAttribute(self.ptr(), name.as_cstr()) };
-
-        if !ptr.is_null() {
-            unsafe {
-                // Safe since we're controlling the lifetime
-                let c_str = CStr::from_ptr(ptr);
-                // We're forcing IUP to use UTF-8 
-                Some(::std::str::from_utf8_unchecked(c_str.to_bytes()))
-            }
-        } else {
-            None
-        }
-    }
-
-    fn set_int_attribute(&mut self, name: &'static str, val: i32) {
-        unsafe { iup_sys::IupSetInt(self.ptr(), name.as_cstr(), val); }
-    }
-
-    fn get_int_attribute(&self, name: &'static str) -> i32 {
-        unsafe { iup_sys::IupGetInt(self.ptr(), name.as_cstr()) }
-    }
-
-    fn get_int2_attribute(&self, name: &'static str) -> (i32, i32) {
-        let mut left = 0;
-        let mut right = 0;
-
-        unsafe { 
-            assert!(iup_sys::IupGetIntInt(self.ptr(), name.as_cstr(), &mut left, &mut right) != 0); 
-        }
-
-        (left, right)
-    }
-
-    fn set_float_attribute(&mut self, name: &'static str, val: f32) {
-        unsafe { iup_sys::IupSetFloat(self.ptr(), name.as_cstr(), val); } 
-    }
-
-    fn get_float_attribute(&self, name: &'static str) -> f32 {
-        unsafe { iup_sys::IupGetFloat(self.ptr(), name.as_cstr()) }
-    }
-
-    fn set_bool_attribute(&mut self, name: &'static str, val: bool) {
-        let val = ::attrs::values::bool_yes_no(val);
-        self.set_const_str_attribute(name, val);        
-    }
-
-    fn set_attr_handle<H: Into<BaseWidget>>(&self, name: &'static str, handle: H) {
-        unsafe { iup_sys::IupSetAttributeHandle(self.ptr(), name.as_cstr(), handle.into().ptr()); }
-    }
-
-    fn get_attr_handle(&self, name: &'static str) -> Option<BaseWidget> {
-        unsafe { 
-            let existing = iup_sys::IupGetAttributeHandle(self.ptr(), name.as_cstr());
-            BaseWidget::from_ptr_opt(existing)
-        }
-    }
-
-    // Should this be `unsafe` since `callback` is a pointer with no lifetime guarantees?
-    fn set_callback(&mut self, name: &'static str, callback: ::iup_sys::Icallback) {
-        unsafe { iup_sys::IupSetCallback(self.ptr(), name.as_cstr(), callback); } 
-    } 
-
-    // Should only be exposed by widget types that need it.
-    fn destroy(self) {
-        unsafe { iup_sys::IupDestroy(self.ptr()); }
-    }
-}
+impl_widget! { BaseWidget, "not an IUP widget!" }
 
 /// A trait describing a widget's ability to be downcast from `BaseWidget`.
-pub trait Downcast: Sized {
+pub trait Downcast: Widget {
     /// Attempt to downcast `base` to the `Self` type, 
     /// returning `Err(base)` if unsuccessful.
     fn try_downcast(base: BaseWidget) -> Result<Self, BaseWidget> {
-        if Self::classname().as_bytes() == base.classname().to_bytes() {
+        if Self::can_downcast(&base) {
             Ok(unsafe { Self::downcast(base) })
         } else {
             Err(base)
@@ -294,48 +50,15 @@ pub trait Downcast: Sized {
     // These are not meant for end-users to call.
     // They are an implementation detail of `try_downcast()`.
     #[doc(hidden)]
-    unsafe fn downcast(base: BaseWidget) -> Self;
+    unsafe fn downcast(base: BaseWidget) -> Self {
+        Self::from_ptr(base.ptr())
+    }
+
     #[doc(hidden)]
-    fn classname() -> &'static str;
+    fn can_downcast(base: &BaseWidget) -> bool {
+        Self::target_classname().as_bytes() == base.classname().to_bytes()
+    }
 }
 
-macro_rules! impl_base_widget {
-    ($ty:ty, $ty_cons:path, $classname:expr) => (
-        impl Into<::base::BaseWidget> for $ty {
-            fn into(self) -> ::base::BaseWidget {
-                self.0
-            }
-        }
-
-        impl ::std::ops::Deref for $ty {
-            type Target = ::base::BaseWidget;
-
-            fn deref(&self) -> &::base::BaseWidget {
-                &self.0
-            }
-        }
-
-        impl ::std::ops::DerefMut for $ty {
-            fn deref_mut(&mut self) -> &mut ::base::BaseWidget {
-                &mut self.0
-            }
-        }
-
-        impl ::base::Downcast for $ty {
-            unsafe fn downcast(base: ::base::BaseWidget) -> $ty {
-                $ty_cons(base)
-            }
-
-            fn classname() -> &'static str {
-                $classname
-            }
-        }
-
-        impl Clone for $ty {
-            fn clone(&self) -> Self {
-                $ty_cons(self.0.clone())
-            }
-        }
-    )
-}
+impl<T: Widget> Downcast for T {}
 

--- a/src/button.rs
+++ b/src/button.rs
@@ -5,25 +5,25 @@ use widget_prelude::*;
 use std::ptr;
 
 /// A button that can be clicked momentarily and invoke a callback when this happens.
-pub struct Button(BaseWidget);
+pub struct Button(IUPPtr);
 
 impl Button {
     /// Create a new `Button` with no label.
     pub fn new() -> Button {
         unsafe {
             let ptr = ::iup_sys::IupButton(ptr::null(), ptr::null());
-            Button(BaseWidget::from_ptr(ptr))
+            Self::from_ptr(ptr)
         }
     }
 
-    /// Set the label of this button if `Some`, remove it otherwise.
-    pub fn set_label<L: Into<String>>(mut self, label: Option<L>) -> Self {
-        self.set_opt_str_attribute(::attrs::TITLE, label);
+    /// Set the label of this button. Can be blank.
+    pub fn set_label<L: Into<String>>(self, label: L) -> Self {
+        self.set_str_attribute(::attrs::TITLE, label);
         self        
     }
 }
 
-impl_base_widget! { Button, Button, "button" }
+impl_widget! { Button, "button" }
 
 impl_onclick! { Button }
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -10,14 +10,14 @@ use container::Orientation;
 /// same as "indefinite")
 ///
 /// [iup-progress]: http://webserver2.tecgraf.puc-rio.br/iup/en/elem/iupprogressbar.html
-pub struct ProgressBar(BaseWidget);
+pub struct ProgressBar(IUPPtr);
 
 impl ProgressBar {
     /// Create a new progress bar.
     pub fn new() -> ProgressBar {
         unsafe {
             let ptr = ::iup_sys::IupProgressBar();
-            ProgressBar(BaseWidget::from_ptr(ptr))
+            Self::from_ptr(ptr)
         }
     }
 
@@ -27,7 +27,7 @@ impl ProgressBar {
     /// show its true value; instead it will render a looping animation.
     ///
     /// This may not have a visual effect on certain platforms. 
-    pub fn set_indefinite(mut self, is_indefinite: bool) -> Self {
+    pub fn set_indefinite(self, is_indefinite: bool) -> Self {
         self.set_bool_attribute(::attrs::MARQUEE, is_indefinite);
         self
     }
@@ -35,7 +35,7 @@ impl ProgressBar {
     /// Set if the progress bar should render solid (`false`) or dashed (`true`).
     ///
     /// This may not have a visual effect on certain platforms.
-    pub fn set_dashed(mut self, dashed: bool) -> Self {
+    pub fn set_dashed(self, dashed: bool) -> Self {
         self.set_bool_attribute(::attrs::DASHED, dashed);
         self
     }
@@ -43,7 +43,7 @@ impl ProgressBar {
     /// Set the maximum value of this progress bar, i.e. the value at which it will show full.
     ///
     /// Defaults to `1.0`.
-    pub fn set_max(mut self, max: f32) -> Self {
+    pub fn set_max(self, max: f32) -> Self {
         self.set_float_attribute(::attrs::MAX, max);
         self
     }
@@ -51,7 +51,7 @@ impl ProgressBar {
     /// Set the minimum value of this progress bar, i.e. the value at which it will be empty.
     ///
     /// Defaults to `0.0`.
-    pub fn set_min(mut self, min: f32) -> Self {
+    pub fn set_min(self, min: f32) -> Self {
         self.set_float_attribute(::attrs::MIN, min);
         self
     }
@@ -61,28 +61,30 @@ impl ProgressBar {
     /// * `Vertical`: The progress bar will render as a vertical bar, and fill from bottom to top.
     /// * `Horizontal`: The progress bar will render as a horizontal bar, and fill from left to
     /// right.
-    pub fn set_orientation(mut self, orientation: Orientation) -> Self {
+    pub fn set_orientation(self, orientation: Orientation) -> Self {
         self.set_const_str_attribute(::attrs::ORIENTATION, orientation.as_cstr());
         self
     } 
 
     /// Set the current value of this progress bar. Its rendered infill will be updated to reflect
     /// the new value in relation to the minimum and maximum.
-    pub fn set_value(&mut self, val: f32) {
-        self.set_float_attribute(::attrs::VALUE, val);        
+    pub fn set_value(self, val: f32) -> Self {
+        self.set_float_attribute(::attrs::VALUE, val);
+        self
     }
     
     /// Get the current value.
-    pub fn get_value(&self) -> f32 {
+    pub fn get_value(self) -> f32 {
         self.get_float_attribute(::attrs::VALUE)
     }
 
     /// Add `amt` to the current value and update it. `amt` may be negative. 
-    pub fn add_value(&mut self, amt: f32) {
+    pub fn add_value(self, amt: f32) -> Self {
         let val = self.get_float_attribute(::attrs::VALUE);
         self.set_float_attribute(::attrs::VALUE, val + amt);
+        self
     }
 }
 
-impl_base_widget! { ProgressBar, ProgressBar, "progressbar" }
+impl_widget! { ProgressBar, "progressbar" }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -6,7 +6,7 @@ use std::ffi::CString;
 use std::ptr;
 
 /// A static widget that renders text within its parent.
-pub struct Label(BaseWidget);
+pub struct Label(IUPPtr);
 
 impl Label {
     /// Create a label with some text. 
@@ -14,7 +14,7 @@ impl Label {
         let c_text = CString::new(text.into()).unwrap();
          unsafe {
             let ptr = ::iup_sys::IupLabel(c_text.as_ptr());
-            Label(BaseWidget::from_ptr(ptr))
+            Self::from_ptr(ptr)
         }
     }
 
@@ -22,13 +22,14 @@ impl Label {
     pub fn new_empty() -> Label {
         unsafe { 
             let ptr = ::iup_sys::IupLabel(ptr::null());
-            Label(BaseWidget::from_ptr(ptr))       
+            Self::from_ptr(ptr)       
         }
     }
 
     /// Update the text of this label.
-    pub fn set_text(&mut self, text: &str) {
+    pub fn set_text(self, text: &str) -> Self {
         self.set_str_attribute(::attrs::TITLE, text);
+        self
     }
 
     /// Get the text of this label.
@@ -37,19 +38,19 @@ impl Label {
     }
 }
 
-impl_base_widget! { Label, Label, "label" }
+impl_widget! { Label, "label" }
 
 impl ::image::ImageContainer for Label {}
 
 /// A widget that renders user-editable text.
-pub struct TextBox(BaseWidget);
+pub struct TextBox(IUPPtr);
 
 impl TextBox {
     /// Create a new, empty text box.
     pub fn new() -> TextBox {
         unsafe {
             let ptr = ::iup_sys::IupText(ptr::null());
-            TextBox(BaseWidget::from_ptr(ptr))
+            Self::from_ptr(ptr)
         }
     }
 
@@ -58,7 +59,7 @@ impl TextBox {
     /// If `false`, it will only be slightly taller than a line of text in the current font.
     /// If `true`, the total dimensions will be set by `set_visible_columns` and
     /// `set_visible_lines`. Text outside these bounds will be accessible with a scrollbar.
-    pub fn set_multiline(mut self, multiline: bool) -> Self {
+    pub fn set_multiline(self, multiline: bool) -> Self {
         self.set_bool_attribute(::attrs::MULTILINE, multiline);
         self
     }
@@ -67,7 +68,7 @@ impl TextBox {
     ///
     /// If the textbox is set as multiline, this will cause additional text beyond the maximum
     /// width to wrap. Otherwise, it can be scrolled only horizontally.
-    pub fn set_visible_columns(mut self, cols: u32) -> Self {
+    pub fn set_visible_columns(self, cols: u32) -> Self {
         self.set_int_attribute(::attrs::VISIBLE_COLUMNS, cols as i32);
         self
     }
@@ -76,14 +77,15 @@ impl TextBox {
     ///
     /// If the textbox is set as multiline, newline characters will push text following them to the
     /// next visible line. Line counts beyond these bounds will cause a scrollbar to be shown.
-    pub fn set_visible_lines(mut self, lines: u32) -> Self {
+    pub fn set_visible_lines(self, lines: u32) ->  Self {
         self.set_int_attribute(::attrs::VISIBLE_LINES, lines as i32);
         self
     }
 
     /// Set the text of this textbox.
-    pub fn set_text(&mut self, value: &str) {
+    pub fn set_text(self, value: &str) -> Self {
         self.set_str_attribute(::attrs::VALUE, value);
+        self
     }
 
     /// Get the text value of this textbox.
@@ -92,7 +94,7 @@ impl TextBox {
     }    
 }
 
-impl_base_widget! { TextBox, TextBox, "text" }
+impl_widget! { TextBox, "text" }
 
 impl_on_value_change! { TextBox }
 

--- a/src/timer.rs
+++ b/src/timer.rs
@@ -11,7 +11,7 @@ use ::callback::Callback;
 /// ##Note: Resource Usage
 /// This struct should be freed by calling `.destroy()` on it when it is no longer in use to free
 /// any resources it has allocated. Otherwise, it will be freed when `kiss_ui::show_gui()` returns.
-pub struct Timer(BaseWidget);
+pub struct Timer(IUPPtr);
 
 impl Timer {
     /// Create a new timer with a default interval.
@@ -20,41 +20,37 @@ impl Timer {
     pub fn new() -> Timer {
         unsafe {
             let ptr = ::iup_sys::IupTimer();
-            Timer(BaseWidget::from_ptr(ptr))
+            Self::from_ptr(ptr)
         }
     }
 
     /// Set the timer interval in milliseconds.
-    pub fn set_interval(mut self, time: u32) -> Self {
+    pub fn set_interval(self, time: u32) -> Self {
         self.set_int_attribute(::attrs::TIME, time as i32);
         self
     }
 
     /// Set a callback to be invoked when the timer interval elapses.
     /// The callback will be invoked on every interval until `.stop()` is called.
-    pub fn set_on_interval<Cb>(mut self, on_interval: Cb) -> Self where Cb: Callback<Self> {
+    pub fn set_on_interval<Cb>(self, on_interval: Cb) -> Self where Cb: Callback<Self> {
        callback_impl! { ::attrs::ACTION_CB, self, on_interval, Timer }
        self
     }
 
     /// Start the timer. The callback will be invoked when the next interval elapses.
-    pub fn start(&mut self) {
+    pub fn start(self) -> Self {
         self.set_bool_attribute(::attrs::RUN, true);
+        self
     }
 
     /// Stop the timer. The callback will not be invoked until the timer is restarted.
-    pub fn stop(&mut self) {
+    pub fn stop(self) -> Self {
         self.set_bool_attribute(::attrs::RUN, false);
-    }
-
-    /// Destroy the timer, freeing its backing resources. If it was running, it will stop.
-    ///
-    /// ##Warning
-    /// Because they share backing resources, this will affect all clones as well.
-    pub fn destroy(self) {
-        self.0.destroy()
-    }
+        self
+    } 
 }
 
-impl_base_widget! { Timer, Timer, "timer" }
+impl_widget! { Timer, "timer" }
+
+impl Destroy for Timer {}
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -1,0 +1,300 @@
+//! Operations common to all widget types.
+
+use utils::cstr::AsCStr;
+
+use base::{BaseWidget, Downcast};
+use dialog::Dialog;
+
+use iup_sys;
+
+use std::ffi::{CStr, CString};
+use std::ptr;
+
+/// Trait implemented for all widget types.
+///
+/// Some methods may not apply to some widgets.
+pub trait Widget: IUPWidget {
+    /// Show this widget if it was previously hidden.
+    ///
+    /// Does nothing if the widget is already shown, or if the operation does not apply.
+    fn show(self) -> Self {
+        unsafe { iup_sys::IupShow(self.ptr()); }
+        self
+    }
+
+    /// Hide this widget if it was previously visible.
+    ///
+    /// Does nothing if the widget is already hidden, or if the operation does not apply.
+    fn hide(self) -> Self {
+        unsafe { iup_sys::IupHide(self.ptr()); }
+        self
+    }
+
+    /// Set the widget's visibility state.
+    ///
+    /// `.set_visible(true)` is equivalent to calling `.show()`, and `.set_visible(false)`
+    /// is equivalent to calling `.hide()`.
+    ///
+    /// Does nothing if the widget is in the same visibility state as the one being set,
+    /// or if the operation does not apply.
+    fn set_visible(self, visible: bool) -> Self {
+        self.set_bool_attribute(::attrs::VISIBLE, visible);
+        self
+    }
+
+    /// Set the widget's enabled state.
+    ///
+    /// When a widget is disabled, it does not react to user interaction or invoke any callbacks.
+    ///
+    /// Does nothing if the widget does not support being disabled.
+    fn set_enabled(self, enabled: bool) -> Self {
+        self.set_bool_attribute(::attrs::ACTIVE, enabled);
+        self
+    }
+
+    /// Set the position of this widget relative to the top-left corner of its parent.
+    ///
+    /// Does nothing if the widget is not renderable or not attached to a parent.
+     fn set_position(self, x: i32, y: i32) -> Self {
+        self.set_str_attribute(::attrs::POSITION, format!("{x},{y}", x=x, y=y));
+        self
+    }
+
+    /// Get the position of this widget relative to the top-left corner of its parent.
+    ///
+    /// Returns (0, 0) if the widget is not renderable, not attached to a parent, or if that is the
+    /// widget's actual relative position.
+    fn get_position(self) -> (i32, i32) {
+        self.get_int2_attribute(::attrs::POSITION)
+    }
+
+    /// Set the name of the widget so it can be found within its parent.
+    ///
+    /// Does nothing if the widget does not support having a name.
+    fn set_name(self, name: &str) -> Self {
+        self.set_str_attribute(::attrs::NAME, name);
+        self
+    }
+
+    /// Get the name of this widget, if the widget supports having a name and one is set.
+    fn get_name(&self) -> Option<&str> {
+        self.get_str_attribute(::attrs::NAME) 
+    }  
+
+    /// Get the next child in the parent after this widget, based on the order in which they were 
+    /// added.
+    ///
+    /// Returns `None` if this widget is an only child or is not attached to a parent.
+    fn get_sibling(self) -> Option<BaseWidget> {
+        unsafe {
+            let ptr = iup_sys::IupGetBrother(self.ptr());
+            BaseWidget::from_ptr_opt(ptr)
+        }
+    }
+
+    /// Get the parent of this widget.
+    ///
+    /// Returns `None` if this widget has no parent.
+    fn get_parent(self) -> Option<BaseWidget> {
+        unsafe {
+            let ptr = iup_sys::IupGetParent(self.ptr());
+            BaseWidget::from_ptr_opt(ptr)
+        }
+    }
+
+    /// Get the containing dialog of this widget.
+    ///
+    /// Returns `None` if this widget is not attached to a dialog.
+    fn get_dialog(self) -> Option<Dialog> {
+        unsafe {
+            let ptr = iup_sys::IupGetDialog(self.ptr());
+            // Note to self: not using UFCS because `downcast()` is an unsafe function.
+            BaseWidget::from_ptr_opt(ptr).map(|base| Dialog::downcast(base))
+        }
+    }
+
+    /// Get the rendered size of this widget, in pixels.
+    ///
+    /// Returns `(0, 0)` if this widget has no rendered size.
+    fn get_size_pixels(self) -> (u32, u32) {
+        let (width, height) = self.get_int2_attribute(::attrs::RASTERSIZE);
+        (width as u32, height as u32)
+    }
+
+    /// Store this widget under `name`, returning the previous widget stored, if any.
+    ///
+    /// It may later be retrieved from any valid KISS-UI context 
+    /// by calling `BaseWidget::load(name)`.
+    fn store<N: Into<String>>(self, name: N) -> Option<BaseWidget> {
+        ::WIDGET_STORE.with(|store| {
+            store.borrow_mut().insert(name.into(), self.to_base())
+        })
+    }
+
+    fn to_base(self) -> BaseWidget {
+        unsafe { BaseWidget::from_ptr(self.ptr()) }
+    }
+}
+
+
+#[doc(hidden)]
+impl<T: IUPWidget> Widget for T {}
+
+pub trait Destroy: Widget {
+    fn destroy(self) {
+        unsafe { iup_sys::IupDestroy(self.ptr()); }
+    }
+}
+
+#[doc(hidden)]
+pub trait IUPWidget: Copy {
+    unsafe fn from_ptr(ptr: *mut iup_sys::Ihandle) -> Self;
+
+    unsafe fn from_ptr_opt(ptr: *mut iup_sys::Ihandle) -> Option<Self> {
+        if !ptr.is_null() {
+            Some(Self::from_ptr(ptr))
+        } else {
+            None
+        }
+    }
+
+    fn ptr(self) -> *mut iup_sys::Ihandle;
+
+    fn target_classname() -> &'static str;
+
+    fn classname(&self) -> &CStr {
+        unsafe { CStr::from_ptr(iup_sys::IupGetClassName(self.ptr())) } 
+    }
+
+    fn set_str_attribute<V>(self, name: &'static str, val: V) where V: Into<String> {
+        let c_val = CString::new(val.into()).unwrap();
+        unsafe { iup_sys::IupSetStrAttribute(self.ptr(), name.as_cstr(), c_val.as_ptr()); }
+    }
+
+    fn set_opt_str_attribute<V>(self, name: &'static str, val: Option<V>) where V: Into<String> {
+        let c_val = val.map(V::into).map(CString::new).map(Result::unwrap);
+        unsafe { 
+            iup_sys::IupSetStrAttribute(
+                self.ptr(),
+                name.as_cstr(),
+                // This looks backwards, but check the docs. It's right.
+                c_val.as_ref().map_or_else(ptr::null, |c_val| c_val.as_ptr())
+            )
+        }
+    }
+
+    fn set_const_str_attribute(self, name: &'static str, val: &'static str) {
+        unsafe { iup_sys::IupSetAttribute(self.ptr(), name.as_cstr(), val.as_cstr()); }
+    }
+
+    fn get_str_attribute(&self, name: &'static str) -> Option<&str> {
+        let ptr = unsafe { iup_sys::IupGetAttribute(self.ptr(), name.as_cstr()) };
+
+        if !ptr.is_null() {
+            unsafe {
+                // Safe since we're controlling the lifetime
+                let c_str = CStr::from_ptr(ptr);
+                // We're forcing IUP to use UTF-8 
+                Some(::std::str::from_utf8_unchecked(c_str.to_bytes()))
+            }
+        } else {
+            None
+        }
+    }
+
+    fn set_int_attribute(self, name: &'static str, val: i32) {
+        unsafe { iup_sys::IupSetInt(self.ptr(), name.as_cstr(), val); }
+    }
+
+    fn get_int_attribute(self, name: &'static str) -> i32 {
+        unsafe { iup_sys::IupGetInt(self.ptr(), name.as_cstr()) }
+    }
+
+    fn get_int2_attribute(self, name: &'static str) -> (i32, i32) {
+        let mut left = 0;
+        let mut right = 0;
+
+        unsafe { 
+            assert!(iup_sys::IupGetIntInt(self.ptr(), name.as_cstr(), &mut left, &mut right) != 0); 
+        }
+
+        (left, right)
+    }
+
+    fn set_float_attribute(self, name: &'static str, val: f32) {
+        unsafe { iup_sys::IupSetFloat(self.ptr(), name.as_cstr(), val); } 
+    }
+
+    fn get_float_attribute(self, name: &'static str) -> f32 {
+        unsafe { iup_sys::IupGetFloat(self.ptr(), name.as_cstr()) }
+    }
+
+    fn set_bool_attribute(self, name: &'static str, val: bool) {
+        let val = ::attrs::values::bool_yes_no(val);
+        self.set_const_str_attribute(name, val);        
+    }
+
+    fn set_attr_handle<W: Widget>(self, name: &'static str, handle: W) {
+        unsafe { iup_sys::IupSetAttributeHandle(self.ptr(), name.as_cstr(), handle.ptr()); }
+    }
+
+    fn get_attr_handle(self, name: &'static str) -> Option<BaseWidget> {
+        unsafe { 
+            let existing = iup_sys::IupGetAttributeHandle(self.ptr(), name.as_cstr());
+            BaseWidget::from_ptr_opt(existing)
+        }
+    }
+
+    fn set_callback(self, name: &'static str, callback: ::iup_sys::Icallback) {
+        unsafe { iup_sys::IupSetCallback(self.ptr(), name.as_cstr(), callback); } 
+    }    
+}
+
+impl<'a, T: IUPWidget> IUPWidget for &'a T {
+    unsafe fn from_ptr(_ptr: *mut iup_sys::Ihandle) -> Self {
+        panic!("Cannot construct an &mut Self from a pointer");
+    }
+
+    fn ptr(self) -> *mut iup_sys::Ihandle {
+        (*self).ptr()
+    }
+
+    fn target_classname() -> &'static str {
+        T::target_classname()
+    }
+}
+
+#[macro_export]
+macro_rules! impl_widget {
+    ($ty:ident, $classname:expr) => {
+        impl ::widget::IUPWidget for $ty {
+            unsafe fn from_ptr(ptr: ::widget_prelude::IUPPtr) -> Self {
+                assert!(
+                    !ptr.is_null(), 
+                    concat!(
+                        concat!("Failed to construct ", stringify!($ty)),
+                        "; pointer returned from IUP was null!"
+                    )                    
+                );
+
+                $ty(ptr)
+            }
+
+            fn ptr(self) -> ::widget_prelude::IUPPtr {
+                self.0
+            }
+
+            fn target_classname() -> &'static str {
+                $classname
+            }            
+        }
+    
+        impl Copy for $ty {}
+        
+        impl Clone for $ty {
+            fn clone(&self) -> Self {
+                *self
+            }
+        }
+    }
+}


### PR DESCRIPTION
Widgets are now `Copy` because `Clone` didn't do anything special anyways, and it makes for some huge ergonomics and simplicity gains.