### PR TITLE
Soundness fixes

### DIFF
--- a/src/base.rs
+++ b/src/base.rs
@@ -2,6 +2,8 @@
 
 use widget_prelude::*;
 
+use ::KISSContext;
+
 use std::borrow::Borrow;
 
 /// A general widget type that can be specialized at runtime via `Downcast`.
@@ -17,11 +19,7 @@ impl BaseWidget {
     /// ##Panics
     /// If called before `kiss_ui::show_gui()` is invoked or after it returns.
     pub fn load<N: Borrow<str>>(name: N) -> Option<BaseWidget> {
-        assert_kiss_running!();
-
-        ::WIDGET_STORE.with(|store| {
-            store.borrow().get(name.borrow()).cloned()
-        })
+        KISSContext::load_widget(&name) 
     }
 
     /// Attempt to downcast this `BaseWidget` to a more specialized widget type.

--- a/src/text.rs
+++ b/src/text.rs
@@ -27,6 +27,9 @@ impl Label {
     }
 
     /// Update the text of this label.
+    ///
+    /// ##Panics
+    /// If any `WidgetStr` instances from `self.get_text()` are still reachable.
     pub fn set_text(self, text: &str) -> Self {
         self.set_str_attribute(::attrs::TITLE, text);
         self
@@ -84,6 +87,9 @@ impl TextBox {
     }
 
     /// Set the text of this textbox.
+    ///
+    /// ##Panics
+    /// If any `WidgetStr` instances from `self.get_text()` are still reachable.
     pub fn set_text(self, value: &str) -> Self {
         self.set_str_attribute(::attrs::VALUE, value);
         self

--- a/src/text.rs
+++ b/src/text.rs
@@ -33,8 +33,9 @@ impl Label {
     }
 
     /// Get the text of this label.
-    pub fn get_text(&self) -> &str {
-        self.get_str_attribute(::attrs::TITLE).unwrap_or("")
+    pub fn get_text(&self) -> WidgetStr {
+        self.get_str_attribute(::attrs::TITLE)
+            .expect("This widget should have a text pointer even if it's empty!")
     }
 }
 
@@ -89,8 +90,9 @@ impl TextBox {
     }
 
     /// Get the text value of this textbox.
-    pub fn get_text(&self) -> &str {
-        self.get_str_attribute(::attrs::VALUE).unwrap_or("")
+    pub fn get_text(&self) -> WidgetStr {
+        self.get_str_attribute(::attrs::VALUE)
+            .expect("This string should be present even if it's empty!")
     }    
 }
 

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -80,6 +80,9 @@ pub trait Widget: IUPWidget {
     /// Set the name of the widget so it can be found within its parent.
     ///
     /// Does nothing if the widget does not support having a name.
+    ///
+    /// ##Panics
+    /// If any `WidgetStr` instances from `self.get_name()` are still reachable.
     fn set_name(self, name: &str) -> Self {
         self.set_str_attribute(::attrs::NAME, name);
         self

--- a/src/widget.rs
+++ b/src/widget.rs
@@ -4,11 +4,20 @@ use utils::cstr::AsCStr;
 
 use base::{BaseWidget, Downcast};
 use dialog::Dialog;
+use widget_prelude::IUPPtr;
+
+use ::KISSContext;
 
 use iup_sys;
 
+use std::borrow::Borrow;
+use std::cell::Cell;
 use std::ffi::{CStr, CString};
+use std::fmt::{self, Debug, Display, Formatter};
+use std::hash::{Hash, Hasher};
+use std::ops::Deref;
 use std::ptr;
+use std::rc::Rc;
 
 /// Trait implemented for all widget types.
 ///
@@ -77,7 +86,7 @@ pub trait Widget: IUPWidget {
     }
 
     /// Get the name of this widget, if the widget supports having a name and one is set.
-    fn get_name(&self) -> Option<&str> {
+    fn get_name(&self) -> Option<WidgetStr> {
         self.get_str_attribute(::attrs::NAME) 
     }  
 
@@ -126,9 +135,7 @@ pub trait Widget: IUPWidget {
     /// It may later be retrieved from any valid KISS-UI context 
     /// by calling `BaseWidget::load(name)`.
     fn store<N: Into<String>>(self, name: N) -> Option<BaseWidget> {
-        ::WIDGET_STORE.with(|store| {
-            store.borrow_mut().insert(name.into(), self.to_base())
-        })
+        KISSContext::store_widget(name, self)
     }
 
     fn to_base(self) -> BaseWidget {
@@ -138,15 +145,79 @@ pub trait Widget: IUPWidget {
 
 pub trait Destroy: Widget {
     fn destroy(self) {
-        unsafe { iup_sys::IupDestroy(self.ptr()); }
+        unsafe { 
+            iup_sys::IupDestroy(self.ptr()); 
+        }
     }
 }
 
+/// A string slice borrowed from a widget's metadata. Can be dereferenced to `&str`.
+///
+/// Tracks ownership of the string so that its pointer cannot be invalidated. Releases ownership
+/// on-drop.
+pub struct WidgetStr<'a> {
+    refcount: Rc<Cell<usize>>, 
+    data: &'a str,
+}
+
+impl<'a> Borrow<str> for WidgetStr<'a> {
+    fn borrow(&self) -> &str {
+        self.data
+    }
+}
+
+impl<'a> Debug for WidgetStr<'a> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+        <str as Debug>::fmt(self.data, fmt)
+    }
+}
+
+impl<'a> Display for WidgetStr<'a> {
+    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+        <str as Display>::fmt(self.data, fmt)
+    }
+}
+
+impl<'a> Hash for WidgetStr<'a> {
+    fn hash<H>(&self, hasher: &mut H) where H: Hasher {
+        self.data.hash(hasher)
+    } 
+}
+
+impl<'a> Deref for WidgetStr<'a> {
+    type Target = str;
+
+    fn deref<'b>(&'b self) -> &'b str {
+        self.data
+    }
+}
+
+impl<'a> Clone for WidgetStr<'a> {
+    fn clone(&self) -> Self {
+        let refcount = self.refcount.get();
+        self.refcount.set(refcount + 1);
+
+        WidgetStr {
+            refcount: self.refcount.clone(),
+            data: self.data,
+        }
+    }
+}
+
+impl<'a> Drop for WidgetStr<'a> {
+    fn drop(&mut self) {
+        let refcount = self.refcount.get();
+        self.refcount.set(refcount - 1);
+    }
+}
+
+
+
 #[doc(hidden)]
 pub trait IUPWidget: Copy {
-    unsafe fn from_ptr(ptr: *mut iup_sys::Ihandle) -> Self;
+    unsafe fn from_ptr(ptr: IUPPtr) -> Self;
 
-    unsafe fn from_ptr_opt(ptr: *mut iup_sys::Ihandle) -> Option<Self> {
+    unsafe fn from_ptr_opt(ptr: IUPPtr) -> Option<Self> {
         if !ptr.is_null() {
             Some(Self::from_ptr(ptr))
         } else {
@@ -154,18 +225,22 @@ pub trait IUPWidget: Copy {
         }
     }
 
-    fn ptr(self) -> *mut iup_sys::Ihandle;
+    fn ptr(self) -> IUPPtr;
 
     fn classname(&self) -> &CStr {
         unsafe { CStr::from_ptr(iup_sys::IupGetClassName(self.ptr())) } 
     }
 
     fn set_str_attribute<V>(self, name: &'static str, val: V) where V: Into<String> {
+        KISSContext::assert_str_not_borrowed(self.ptr(), name);
+
         let c_val = CString::new(val.into()).unwrap();
         unsafe { iup_sys::IupSetStrAttribute(self.ptr(), name.as_cstr(), c_val.as_ptr()); }
     }
 
     fn set_opt_str_attribute<V>(self, name: &'static str, val: Option<V>) where V: Into<String> {
+        KISSContext::assert_str_not_borrowed(self.ptr(), name);
+
         let c_val = val.map(V::into).map(CString::new).map(Result::unwrap);
         unsafe { 
             iup_sys::IupSetStrAttribute(
@@ -178,10 +253,12 @@ pub trait IUPWidget: Copy {
     }
 
     fn set_const_str_attribute(self, name: &'static str, val: &'static str) {
+        KISSContext::assert_str_not_borrowed(self.ptr(), name);        
+
         unsafe { iup_sys::IupSetAttribute(self.ptr(), name.as_cstr(), val.as_cstr()); }
     }
 
-    fn get_str_attribute(&self, name: &'static str) -> Option<&str> {
+    fn get_str_attribute(&self, name: &'static str) -> Option<WidgetStr> {
         let ptr = unsafe { iup_sys::IupGetAttribute(self.ptr(), name.as_cstr()) };
 
         if !ptr.is_null() {
@@ -189,7 +266,12 @@ pub trait IUPWidget: Copy {
                 // Safe since we're controlling the lifetime
                 let c_str = CStr::from_ptr(ptr);
                 // We're forcing IUP to use UTF-8 
-                Some(::std::str::from_utf8_unchecked(c_str.to_bytes()))
+                let str_data = ::std::str::from_utf8_unchecked(c_str.to_bytes());
+
+                Some(WidgetStr {
+                    refcount: KISSContext::str_refcount(self.ptr(), name),
+                    data: str_data,
+                })
             }
         } else {
             None


### PR DESCRIPTION
* KISS-UI is forbidden to run in more than one thread (went from thread-local flag to static atomic boolean), since I believe most GUI toolkits don't support more than one running instance at a time.
* Consolidated thread-local data to one object (may put in `Box` so we don't consume too much TLS)

And the big fix:

* String slices from widget metadata are now tracked so that they cannot be updated while there are references to them. Mostly non-breaking except for client code that depended on string accessors returning `&str`.

Closes #29.